### PR TITLE
Fix SlackService webhook typo

### DIFF
--- a/notification-service/utils.py
+++ b/notification-service/utils.py
@@ -142,7 +142,8 @@ class SlackService:
             channel (str): The Slack channel to which messages will be sent.
         """
 
-        self.webook = webhook
+        # Store the Slack incoming webhook URL
+        self.webhook = webhook
         self.channel = channel
 
     def send(self, msg: str) -> None:
@@ -172,5 +173,5 @@ class SlackService:
 
         headers = {"content-type": "application/json"}
         requests.post(
-            self.webook, headers=headers, data=json.dumps(payload), timeout=60
+            self.webhook, headers=headers, data=json.dumps(payload), timeout=60
         )


### PR DESCRIPTION
## Summary
- fix `self.webook` typo and rename to `self.webhook`
- post Slack payload to the correct attribute
- add clarifying inline comment

## Testing
- `python -m py_compile notification-service/utils.py`

